### PR TITLE
Add usage tracking for all backends

### DIFF
--- a/lib/strider/context.ex
+++ b/lib/strider/context.ex
@@ -25,10 +25,11 @@ defmodule Strider.Context do
 
   @type t :: %__MODULE__{
           messages: [Message.t()],
-          metadata: map()
+          metadata: map(),
+          usage: map()
         }
 
-  defstruct messages: [], metadata: %{}
+  defstruct messages: [], metadata: %{}, usage: %{input_tokens: 0, output_tokens: 0}
 
   @doc """
   Creates a new empty context.
@@ -161,5 +162,33 @@ defmodule Strider.Context do
   @spec clear(t()) :: t()
   def clear(%__MODULE__{} = context) do
     %{context | messages: []}
+  end
+
+  @doc """
+  Returns the accumulated usage for the context.
+
+  ## Examples
+
+      iex> context = Strider.Context.new()
+      iex> Strider.Context.usage(context)
+      %{input_tokens: 0, output_tokens: 0}
+
+  """
+  @spec usage(t()) :: map()
+  def usage(%__MODULE__{usage: usage}), do: usage
+
+  @doc """
+  Returns the total number of tokens used in the context.
+
+  ## Examples
+
+      iex> context = Strider.Context.new()
+      iex> Strider.Context.total_tokens(context)
+      0
+
+  """
+  @spec total_tokens(t()) :: non_neg_integer()
+  def total_tokens(%__MODULE__{usage: usage}) do
+    Map.get(usage, :input_tokens, 0) + Map.get(usage, :output_tokens, 0)
   end
 end

--- a/lib/strider/telemetry.ex
+++ b/lib/strider/telemetry.ex
@@ -46,6 +46,10 @@ if Code.ensure_loaded?(:telemetry) do
       - Measurements: `%{}`
       - Metadata: `%{agent: Agent.t(), chunk: map(), context: Context.t()}`
 
+    - `[:strider, :stream, :usage]` - When a stream chunk includes usage
+      - Measurements: `%{input_tokens: integer, output_tokens: integer}`
+      - Metadata: `%{agent: Agent.t(), context: Context.t(), usage_stage: :partial | :final}`
+
     - `[:strider, :stream, :stop]` - When streaming completes
       - Measurements: `%{system_time: integer}`
       - Metadata: `%{agent: Agent.t(), context: Context.t()}`
@@ -93,6 +97,7 @@ if Code.ensure_loaded?(:telemetry) do
         [:strider, :call, :error],
         [:strider, :stream, :start],
         [:strider, :stream, :chunk],
+        [:strider, :stream, :usage],
         [:strider, :stream, :stop],
         [:strider, :backend, :request],
         [:strider, :backend, :response]

--- a/lib/strider/telemetry/hooks.ex
+++ b/lib/strider/telemetry/hooks.ex
@@ -74,6 +74,20 @@ if Code.ensure_loaded?(:telemetry) do
         %{},
         %{agent: agent, chunk: chunk, context: context}
       )
+
+      usage = get_in(chunk, [:metadata, :usage])
+
+      if is_map(usage) do
+        :telemetry.execute(
+          [:strider, :stream, :usage],
+          usage,
+          %{
+            usage_stage: get_in(chunk, [:metadata, :usage_stage]) || :partial,
+            agent: agent,
+            context: context
+          }
+        )
+      end
     end
 
     @impl true

--- a/test/strider/context_test.exs
+++ b/test/strider/context_test.exs
@@ -136,4 +136,32 @@ defmodule Strider.ContextTest do
       assert Context.get_metadata(context, :missing, "default") == "default"
     end
   end
+
+  describe "usage/1" do
+    test "returns default usage for new context" do
+      context = Context.new()
+
+      assert Context.usage(context) == %{input_tokens: 0, output_tokens: 0}
+    end
+
+    test "returns accumulated usage" do
+      context = %{Context.new() | usage: %{input_tokens: 100, output_tokens: 50}}
+
+      assert Context.usage(context) == %{input_tokens: 100, output_tokens: 50}
+    end
+  end
+
+  describe "total_tokens/1" do
+    test "returns 0 for new context" do
+      context = Context.new()
+
+      assert Context.total_tokens(context) == 0
+    end
+
+    test "returns sum of input and output tokens" do
+      context = %{Context.new() | usage: %{input_tokens: 100, output_tokens: 50}}
+
+      assert Context.total_tokens(context) == 150
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Add general usage tracking that accumulates across calls in Context
- Emit telemetry events for streaming usage
- Support usage tracking in all backends (ReqLLM, Mock, BAML)

## Changes

### Context-based tracking (sync calls)
- Add `usage` field to `Context` struct with `%{input_tokens: 0, output_tokens: 0}`
- Add `Context.usage/1` and `Context.total_tokens/1` helpers
- Accumulate usage in `Runtime.add_exchange_to_context/3` after each call

### Telemetry for streaming
- Emit `[:strider, :stream, :usage]` event when chunks include usage metadata
- Stream chunk contract: `%{content: term(), metadata: %{usage: %{...}, usage_stage: :partial | :final}}`

### Backend support
- **ReqLLM**: Append final chunk with usage from `ReqLLM.StreamResponse.usage/1`
- **Mock**: Support `:stream_usage` config option for testing telemetry
- **BAML**: Use `BamlElixir.Collector` for both sync and streaming calls

## Test plan
- [x] Context usage helper tests pass
- [x] Runtime usage accumulation tests pass
- [x] Telemetry streaming usage event tests pass
- [x] Full test suite passes (244 tests, 0 failures)